### PR TITLE
Update zone metadata API call to v3 as v2 no longer works

### DIFF
--- a/octodns_ultra/__init__.py
+++ b/octodns_ultra/__init__.py
@@ -149,24 +149,21 @@ class UltraProvider(BaseProvider):
     @property
     def zones(self):
         if self._zones is None:
-            offset = 0
             limit = self.ZONE_REQUEST_LIMIT
             zones = []
             paging = True
             while paging:
-                data = {'limit': limit, 'q': 'zone_type:PRIMARY',
-                        'offset': offset}
+                data = {'limit': limit, 'q': 'zone_type:PRIMARY'}
                 try:
-                    resp = self._get('/v2/zones', params=data)
+                    resp = self._get('/v3/zones', params=data)
                 except UltraNoZonesExistException:
                     paging = False
                     continue
 
                 zones.extend(resp['zones'])
-                info = resp['resultInfo']
 
-                if info['offset'] + info['returnedCount'] < info['totalCount']:
-                    offset += info['returnedCount']
+                if 'next' in resp['cursorInfo']:
+                    data['cursor'] = resp['cursorInfo']['next']
                 else:
                     paging = False
 

--- a/octodns_ultra/__init__.py
+++ b/octodns_ultra/__init__.py
@@ -26,6 +26,7 @@ class UltraNoZonesExistException(UltraClientException):
     This is not an error exactly yet ultra treats this scenario as though a
     failure has occurred.
     '''
+
     def __init__(self, data):
         super(UltraNoZonesExistException, self).__init__('NoZonesExist')
 
@@ -34,6 +35,7 @@ class UltraClientUnauthorized(UltraClientException):
     '''
     Exception for invalid credentials.
     '''
+
     def __init__(self):
         super(UltraClientUnauthorized, self).__init__('Unauthorized')
 
@@ -151,9 +153,9 @@ class UltraProvider(BaseProvider):
         if self._zones is None:
             limit = self.ZONE_REQUEST_LIMIT
             zones = []
+            data = {'limit': limit, 'q': 'zone_type:PRIMARY'}
             paging = True
             while paging:
-                data = {'limit': limit, 'q': 'zone_type:PRIMARY'}
                 try:
                     resp = self._get('/v3/zones', params=data)
                 except UltraNoZonesExistException:

--- a/tests/fixtures/ultra-zones-page-1.json
+++ b/tests/fixtures/ultra-zones-page-1.json
@@ -5,10 +5,9 @@
         "reverse": false,
         "limit": 10
     },
-    "resultInfo": {
-        "totalCount": 20,
-        "offset": 0,
-        "returnedCount": 10
+    "cursorInfo": {
+        "next": "b2N0b2RuczE4LnRlc3QuOk5FWFQK",
+        "last": "fjpMQVNU"
     },
     "zones": [
         {

--- a/tests/fixtures/ultra-zones-page-2.json
+++ b/tests/fixtures/ultra-zones-page-2.json
@@ -5,10 +5,9 @@
         "reverse": false,
         "limit": 10
     },
-    "resultInfo": {
-        "totalCount": 20,
-        "offset": 10,
-        "returnedCount": 10
+    "cursorInfo": {
+        "previous": "b2N0b2RuczE5LnRlc3QuOlBSRVZJT1VT",
+        "first": "OkZJUlNU"
     },
     "zones": [
         {


### PR DESCRIPTION
From : https://docs.ultradns.neustar/Content/REST%20API/Content/REST%20API/Zone%20API/Zone%20API.htm#List_Metadata_for_Zones-v3

```
We highly recommend that users begin to utilize the List Metadata for Zones – v3 call as soon as possible to prevent any errors or confusion once the API call is officially decommissioned. This call will be deprecated as of 2022-05-15 at 23:59:59 UTC.
```