### PR TITLE
Rel 0.0.2 version bump & CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.2 - 2022-10-10 - APIs gonna break
+
+* Update zone metadata API call to v3 as v2 no longer works
+
 ## v0.0.1 - 2022-01-17 - Moving
 
 #### Nothworthy Changes

--- a/octodns_ultra/__init__.py
+++ b/octodns_ultra/__init__.py
@@ -10,7 +10,7 @@ from octodns.record import Record
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 class UltraClientException(ProviderException):


### PR DESCRIPTION
## v0.0.2 - 2022-10-10 - APIs gonna break

* Update zone metadata API call to v3 as v2 no longer works

/cc Fixes https://github.com/octodns/octodns-ultra/issues/10 @ryanc