### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_provider_octodns_ultra.py
+++ b/tests/test_provider_octodns_ultra.py
@@ -28,7 +28,9 @@ def _get_provider():
             text='{"token type": "Bearer", "refresh_token": "abc", '
             '"access_token":"123", "expires_in": "3600"}',
         )
-        return UltraProvider('test', 'testacct', 'user', 'pass')
+        return UltraProvider(
+            'test', 'testacct', 'user', 'pass', strict_supports=False
+        )
 
 
 class TestUltraProvider(TestCase):


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957