### PR TITLE
Enable SUPPORTS_ROOT_NS for UltraDNS provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.3 - 2023-??-??
+
+* Enable support for root level NS records (`SUPPORTS_ROOT_NS=true`)
+
 ## v0.0.2 - 2022-10-10 - APIs gonna break
 
 * Update zone metadata API call to v3 as v2 no longer works

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ providers:
 
 ### Support Information
 
+Ultra provider supports full root NS record management.
+
 #### Records
 
 UltraProvider supports A, AAAA, CAA, CNAME, MX, NS, PTR, SPF, SRV, and TXT

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ providers:
 
 UltraProvider supports A, AAAA, CAA, CNAME, MX, NS, PTR, SPF, SRV, and TXT
 
+#### Root NS Records
+
+UltraProvider supports full root NS record management.
+
 #### Dynamic
 
 UltraProvider does not support dynamic records.
@@ -57,7 +61,3 @@ UltraProvider does not support dynamic records.
 ### Development
 
 See the [/script/](/script/) directory for some tools to help with the development process. They generally follow the [Script to rule them all](https://github.com/github/scripts-to-rule-them-all) pattern. Most useful is `./script/bootstrap` which will create a venv and install both the runtime and development related requirements. It will also hook up a pre-commit hook that covers most of what's run by CI.
-
-#### Root NS Records
-
-UltraProvider supports full root NS record management.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ providers:
 
 ### Support Information
 
-Ultra provider supports full root NS record management.
-
 #### Records
 
 UltraProvider supports A, AAAA, CAA, CNAME, MX, NS, PTR, SPF, SRV, and TXT
@@ -59,3 +57,7 @@ UltraProvider does not support dynamic records.
 ### Development
 
 See the [/script/](/script/) directory for some tools to help with the development process. They generally follow the [Script to rule them all](https://github.com/github/scripts-to-rule-them-all) pattern. Most useful is `./script/bootstrap` which will create a venv and install both the runtime and development related requirements. It will also hook up a pre-commit hook that covers most of what's run by CI.
+
+#### Root NS Records
+
+UltraProvider supports full root NS record management.

--- a/octodns_ultra/__init__.py
+++ b/octodns_ultra/__init__.py
@@ -70,6 +70,7 @@ class UltraProvider(BaseProvider):
     TYPE_TO_RECORDS = {v: k for k, v in RECORDS_TO_TYPE.items()}
     SUPPORTS = set(TYPE_TO_RECORDS.keys())
 
+    SUPPORTS_ROOT_NS = True
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
     TIMEOUT = 5

--- a/tests/test_provider_octodns_ultra.py
+++ b/tests/test_provider_octodns_ultra.py
@@ -353,12 +353,12 @@ class TestUltraProvider(TestCase):
             None,  # zone create
         ] + [
             None
-        ] * 15  # individual record creates
+        ] * 16  # individual record creates
 
         # non-existent zone, create everything
         plan = provider.plan(self.expected)
-        self.assertEqual(15, len(plan.changes))
-        self.assertEqual(15, provider.apply(plan))
+        self.assertEqual(16, len(plan.changes))
+        self.assertEqual(16, provider.apply(plan))
         self.assertFalse(plan.exists)
 
         provider._request.assert_has_calls(
@@ -408,7 +408,7 @@ class TestUltraProvider(TestCase):
             True,
         )
         # expected number of total calls
-        self.assertEqual(17, provider._request.call_count)
+        self.assertEqual(18, provider._request.call_count)
 
         # Create sample rrset payload to attempt to alter
         page1 = json_load(open('tests/fixtures/ultra-records-page-1.json'))


### PR DESCRIPTION
I've tested this code change on a test domain in the live API, and it accepted changes to values in the root NS record.

Updated tests to account for new number of records (which now include the NS records) in plans and applies.