### PR TITLE
Increase request page size from 100 to 1000 for RRSET requests.

### DIFF
--- a/octodns_ultra/__init__.py
+++ b/octodns_ultra/__init__.py
@@ -77,6 +77,7 @@ class UltraProvider(BaseProvider):
     SUPPORTS_DYNAMIC = False
     TIMEOUT = 5
     ZONE_REQUEST_LIMIT = 1000
+    RRSET_REQUEST_LIMIT = 1000
 
     def _request(
         self,
@@ -282,7 +283,7 @@ class UltraProvider(BaseProvider):
             records = []
             path = f'/v2/zones/{zone.name}/rrsets'
             offset = 0
-            limit = 100
+            limit = self.RRSET_REQUEST_LIMIT
             paging = True
             while paging:
                 resp = self._get(

--- a/tests/test_provider_octodns_ultra.py
+++ b/tests/test_provider_octodns_ultra.py
@@ -276,7 +276,7 @@ class TestUltraProvider(TestCase):
                 json=zone_payload,
             )
             mock.get(
-                f'{self.host}{rec_path}?offset=0&limit=100',
+                f'{self.host}{rec_path}?offset=0&limit=1000',
                 status_code=200,
                 json=records_payload,
             )
@@ -326,14 +326,14 @@ class TestUltraProvider(TestCase):
             with open('tests/fixtures/ultra-records-page-1.json') as fh:
                 rec_path = '/v2/zones/octodns1.test./rrsets'
                 mock.get(
-                    f'{self.host}{rec_path}?offset=0&limit=100',
+                    f'{self.host}{rec_path}?offset=0&limit=1000',
                     status_code=200,
                     text=fh.read(),
                 )
             with open('tests/fixtures/ultra-records-page-2.json') as fh:
                 rec_path = '/v2/zones/octodns1.test./rrsets'
                 mock.get(
-                    f'{self.host}{rec_path}?offset=10&limit=100',
+                    f'{self.host}{rec_path}?offset=10&limit=1000',
                     status_code=200,
                     text=fh.read(),
                 )


### PR DESCRIPTION
The context is in the previous PR https://github.com/octodns/octodns-ultra/pull/25. There are actually two limits: one for listing zones and one for listing records. I missed the latter in the previous PR.