### PR TITLE
Add list_zones()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
-## v0.0.4 - 2024-01-25
-
-* Enable support for wildcard zone lookups (list_zones())
-
 ## v0.0.3 - 2023-??-??
 
 * Enable support for root level NS records (`SUPPORTS_ROOT_NS=true`)
+* Enable support for wildcard zone lookups (list_zones())
+
 
 ## v0.0.2 - 2022-10-10 - APIs gonna break
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.4 - 2024-01-25
+
+* Enable support for wildcard zone lookups (list_zones())
+
 ## v0.0.3 - 2023-??-??
 
 * Enable support for root level NS records (`SUPPORTS_ROOT_NS=true`)

--- a/octodns_ultra/__init__.py
+++ b/octodns_ultra/__init__.py
@@ -201,6 +201,9 @@ class UltraProvider(BaseProvider):
 
         return self._zones
 
+    def list_zones(self):
+        return self.zones
+
     def _data_for_multiple(self, _type, records):
         return {
             'ttl': records['ttl'],

--- a/tests/test_provider_octodns_ultra.py
+++ b/tests/test_provider_octodns_ultra.py
@@ -139,6 +139,10 @@ class TestUltraProvider(TestCase):
             self.assertEqual(1, mock.call_count)
             self.assertEqual(1, len(zones))
             self.assertEqual('testzone123.com.', zones[0])
+            zones = provider.list_zones()
+            self.assertEqual(1, mock.call_count)
+            self.assertEqual(1, len(zones))
+            self.assertEqual('testzone123.com.', zones[0])
 
         # Test different paging behavior
         provider._zones = None


### PR DESCRIPTION
Add list_zones() method to support wildcard lookup.  Fixes [#40](https://github.com/octodns/octodns-ultra/issues/40).