### PR TITLE
Skip unsupported record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.5 - 2024-01-25
+
+* Skip unsupported dynamic record type "Directional Pool"
+
 ## v0.0.4 - 2024-01-25
 
 * Enable support for wildcard zone lookups (list_zones())

--- a/octodns_ultra/__init__.py
+++ b/octodns_ultra/__init__.py
@@ -330,7 +330,7 @@ class UltraProvider(BaseProvider):
                     continue
                 if (
                     record['rrtype'] == 'A (1)'
-                    and record.get('profile', {}).get('@context'])
+                    and record.get('profile', {}).get('@context')
                     == 'http://schemas.ultradns.com/DirPool.jsonschema'
                 ):
                     self.log.warning(

--- a/octodns_ultra/__init__.py
+++ b/octodns_ultra/__init__.py
@@ -330,8 +330,7 @@ class UltraProvider(BaseProvider):
                     continue
                 if (
                     record['rrtype'] == 'A (1)'
-                    and 'profile' in record
-                    and record['profile']['@context']
+                    and record.get('profile', {}).get('@context'])
                     == 'http://schemas.ultradns.com/DirPool.jsonschema'
                 ):
                     self.log.warning(

--- a/octodns_ultra/__init__.py
+++ b/octodns_ultra/__init__.py
@@ -328,6 +328,19 @@ class UltraProvider(BaseProvider):
                 name = zone.hostname_from_fqdn(record['ownerName'])
                 if record['rrtype'] == 'SOA (6)':
                     continue
+                if (
+                    record['rrtype'] == 'A (1)'
+                    and 'profile' in record
+                    and record['profile']['@context']
+                    == 'http://schemas.ultradns.com/DirPool.jsonschema'
+                ):
+                    self.log.warning(
+                        'populate: ignoring record with '
+                        'unsupported type, %s  %s',
+                        name,
+                        '[Directional Pool (Dynamic)]',
+                    )
+                    continue
                 try:
                     _type = self.RECORDS_TO_TYPE[record['rrtype']]
                 except KeyError:

--- a/octodns_ultra/__init__.py
+++ b/octodns_ultra/__init__.py
@@ -334,10 +334,8 @@ class UltraProvider(BaseProvider):
                     == 'http://schemas.ultradns.com/DirPool.jsonschema'
                 ):
                     self.log.warning(
-                        'populate: ignoring record with '
-                        'unsupported type, %s  %s',
+                        'populate: ignoring record with unsupported type, %s [Directional Pool (Dynamic)]',
                         name,
-                        '[Directional Pool (Dynamic)]',
                     )
                     continue
                 try:

--- a/tests/fixtures/ultra-records-page-1.json
+++ b/tests/fixtures/ultra-records-page-1.json
@@ -84,6 +84,48 @@
             "rdata": [
                 "v=spf1 -all"
             ]
+        },
+        {
+            "ownerName": "dirpool.octodns1.test.",
+            "profile": {
+                "@context": "http://schemas.ultradns.com/DirPool.jsonschema",
+                "description": "dirpool.octodns1.test",
+                "ignoreECS": false,
+                "rdataInfo": [
+                    {
+                        "allNonConfigured": true,
+                        "ttl": 600,
+                        "type": "A"
+                    },
+                    {
+                        "geoInfo": {
+                            "codes": [
+                                "CA"
+                            ],
+                            "name": "xxx"
+                        },
+                        "ttl": 86400,
+                        "type": "SF"
+                    },
+                    {
+                        "geoInfo": {
+                            "codes": [
+                                "ASI",
+                                "OCN"
+                            ],
+                            "name": "yyy"
+                        },
+                        "ttl": 86400,
+                        "type": "SF"
+                    }
+                ]
+            },
+            "rdata": [
+                "127.0.0.1",
+                "xxxrecord.octodns1.test.",
+                "yyyrecord.octodns1.test."
+            ],
+            "rrtype": "A (1)"
         }
     ],
     "resultInfo": {


### PR DESCRIPTION
When querying Directional Pool records, octodns would crash.  This skips them and prints a warning.  Fixes #39.