### PR TITLE
Log the server response when an HTTP error is raised

### DIFF
--- a/octodns_ultra/__init__.py
+++ b/octodns_ultra/__init__.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from logging import getLogger
 
 from requests import Session
+from requests.exceptions import HTTPError
 
 from octodns import __VERSION__ as octodns_version
 from octodns.provider import ProviderException
@@ -117,7 +118,18 @@ class UltraProvider(BaseProvider):
                 raise UltraNoZonesExistException(resp)
         else:
             payload = resp.text
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except HTTPError:
+            self.log.exception(
+                "_request: method=%s, url=%s, response=%s, reason=%s, body=%s",
+                method,
+                url,
+                resp,
+                resp.reason,
+                resp.text,
+            )
+            raise
         return payload
 
     def _get(self, path, **kwargs):


### PR DESCRIPTION
Hello,

Occasionally, our OctoDNS pipeline will fail with UltraDNS due to a server-side error. A message like the following is logged.

```
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://restapi.ultradns.com/v2/zones/example.com./rrsets/TXT/example.com.
```

If I am in a hurry, I will hack in some print statements to determine what the Ultra REST API error is, so I thought that it would be handy to contribute a patch upstream to provide more details about the sync failure. The merge request will cause OctoDNS to log errors like this during an HTTP error.

```
2025-02-19T17:05:30  [281473443368992] ERROR UltraProvider[ultra] _request: method=PUT, url=https://restapi.ultradns.com/v2/zones/example.com./rrsets/A/www.example.com., response=<Response [400]>,  reason=Bad Request, body=[{"errorCode":2136,"errorMessage":"The TTL you have defined for this record type does not meet the Global Minimum TTL. Please enter a TTL greater than the Global Minimum TTL setting. Global Minimum TTL value 300 and  Global Maximum TTL value 86400"}]
```

Thanks!