### PR TITLE
Fix script/format type-o w/ns1 module

### DIFF
--- a/.changelog/5e670ec7bc2b4a1fa2fd2b716979922a.md
+++ b/.changelog/5e670ec7bc2b4a1fa2fd2b716979922a.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Fix ns1 type-o in script/format

--- a/script/format
+++ b/script/format
@@ -5,7 +5,7 @@ SCRIPT_PATH="$( dirname -- "$( readlink -f -- "${0}"; )"; )"
 # Activate OctoDNS Python venv
 source "${SCRIPT_PATH}/common.sh"
 
-SOURCES="$(find *.py octodns_ns1 tests -name "*.py") $(grep --files-with-matches '^#!.*python' script/*)"
+SOURCES="$(find *.py octodns_route53 tests -name "*.py") $(grep --files-with-matches '^#!.*python' script/*)"
 
 isort "$@" $SOURCES
 black "$@" $SOURCES


### PR DESCRIPTION
Move all the common venv handling code of scripts into common.sh

/cc octodns/octodns#1324 which started the common.sh pattern