### PR TITLE
Explicit non-escaped semicolons for YamlProvider

### DIFF
--- a/.changelog/51ebf62e482e47f4a6dc01a76817118a.md
+++ b/.changelog/51ebf62e482e47f4a6dc01a76817118a.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Explicit non-escaped semicolons for YamlProvider

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -146,7 +146,7 @@ txt:
   values:
     - Bah bah black sheep
     - have you any wool.
-    - 'v=DKIM1\;k=rsa\;s=email\;h=sha256\;p=A/kinda+of/long/string+with+numb3rs'
+    - 'v=DKIM1;k=rsa;s=email;h=sha256;p=A/kinda+of/long/string+with+numb3rs'
 urlfwd:
   ttl: 300
   type: URLFWD

--- a/tests/test_provider_octodns_ultra.py
+++ b/tests/test_provider_octodns_ultra.py
@@ -41,7 +41,9 @@ class TestUltraProvider(TestCase):
     empty_body = [{"errorCode": 70002, "errorMessage": "Data not found."}]
 
     expected = Zone('unit.tests.', [])
-    source = YamlProvider('test', join(dirname(__file__), 'config'))
+    source = YamlProvider(
+        'test', join(dirname(__file__), 'config'), escaped_semicolons=False
+    )
     source.populate(expected)
 
     def test_login(self):


### PR DESCRIPTION
YamlProvider is going to default to escaped_semicolons=False in 2.x, until then we'll explicitly ask for it to get tests happy w/o the deprecated warning.

/cc https://github.com/octodns/octodns/pull/1419